### PR TITLE
Fix registration flow and CV analysis endpoint

### DIFF
--- a/src/components/AuthContext.jsx
+++ b/src/components/AuthContext.jsx
@@ -201,15 +201,24 @@ export const AuthProvider = ({ children }) => {
       }
 
       const data = await response.json();
-      
-      // Handle new response format
-      const { user: userData, access_token } = data;
-      
+
+      // New API might not return token/user. Fallback to login when missing
+      let { user: userData, access_token } = data;
+      if (!access_token) {
+        // Attempt to login to obtain token
+        await login(username, password);
+        access_token = storage.get('token');
+        userData = storage.get('user');
+        // Prefetch jobs after successful login
+        fetchJobs();
+        return { user: userData, token: access_token };
+      }
+
       // Set authentication state
       setToken(access_token);
       setIsAuthenticated(true);
       setUser(userData);
-      
+
       // Store in localStorage
       storage.set('user', userData);
       storage.set('token', access_token);
@@ -218,7 +227,7 @@ export const AuthProvider = ({ children }) => {
       // Start fetching data in background
       fetchProfile();
       fetchJobs();
-      
+
       // Return immediately with needed data
       return {
         user: userData,
@@ -228,7 +237,7 @@ export const AuthProvider = ({ children }) => {
       console.error('Registration error:', error);
       throw error;
     }
-  }, [fetchProfile, fetchJobs]);
+  }, [fetchProfile, fetchJobs, login]);
 
   const logout = useCallback(() => {
     ['isAuthenticated', 'user', 'token'].forEach(key => storage.remove(key));

--- a/src/components/CvAnalysisResults.jsx
+++ b/src/components/CvAnalysisResults.jsx
@@ -12,7 +12,7 @@ const CvAnalysisResults = ({ extractedInfo, relatedFields, filename = 'cv.pdf', 
       if (!token || analysisSubmitted) return;
 
       try {
-        const response = await fetch('http://api.smartcareerassistant.online/auth/cv-analysis', {
+        const response = await fetch('https://api.smartcareerassistant.online/cv-analysis', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',

--- a/src/components/Register.jsx
+++ b/src/components/Register.jsx
@@ -76,7 +76,7 @@ const Register = () => {
       if (pendingAnalysis) {
         try {
           const { fileInfo, relatedFields } = JSON.parse(pendingAnalysis);
-          fetch('https://api.smartcareerassistant.online/auth/cv-analysis', {
+          fetch('https://api.smartcareerassistant.online/cv-analysis', {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- Ensure registration logs users in when backend omits access token
- Correct CV analysis API endpoint to prevent 404 errors

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0bc511558832ca4a25a2510ae60c7