### PR TITLE
Fix registration flow and CV analysis endpoint

### DIFF
--- a/src/components/CvAnalysisResults.jsx
+++ b/src/components/CvAnalysisResults.jsx
@@ -12,7 +12,7 @@ const CvAnalysisResults = ({ extractedInfo, relatedFields, filename = 'cv.pdf', 
       if (!token || analysisSubmitted) return;
 
       try {
-        const response = await fetch('http://api.smartcareerassistant.online/auth/cv-analysis', {
+        const response = await fetch('https://api.smartcareerassistant.online/cv-analysis', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',

--- a/src/components/Register.jsx
+++ b/src/components/Register.jsx
@@ -66,21 +66,27 @@ const Register = () => {
     setLoading(true);
 
     try {
-      const userData = await register(formData.username, formData.email, formData.password, selectedField, formData.technicalSkillsPercentage);
-      
+      const userData = await register(
+        formData.username,
+        formData.email,
+        formData.password,
+        selectedField,
+        formData.technicalSkillsPercentage
+      );
+
       // Redirect to dashboard immediately
       navigate('/dashboard', { state: { selectedField, user: userData } });
-      
-      // Submit CV analysis in background if exists
+
+      // Submit CV analysis in background if exists and we have a token
       const pendingAnalysis = sessionStorage.getItem('pendingCvAnalysis');
-      if (pendingAnalysis) {
+      if (pendingAnalysis && userData?.token) {
         try {
           const { fileInfo, relatedFields } = JSON.parse(pendingAnalysis);
-          fetch('https://api.smartcareerassistant.online/auth/cv-analysis', {
+          fetch('https://api.smartcareerassistant.online/cv-analysis', {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
-              'Authorization': `Bearer ${userData.token}`
+              Authorization: `Bearer ${userData.token}`
             },
             body: JSON.stringify({
               filename: fileInfo.filename,


### PR DESCRIPTION
## Summary
- Ensure post-signup login uses email when backend omits token
- Guard background CV analysis submission when authentication is missing

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0bc511558832ca4a25a2510ae60c7