### PR TITLE
Improve login fallback and register redirect logic

### DIFF
--- a/src/components/AuthContext.jsx
+++ b/src/components/AuthContext.jsx
@@ -205,8 +205,16 @@ export const AuthProvider = ({ children }) => {
       // New API might not return token/user. Fallback to login when missing
       let { user: userData, access_token } = data;
       if (!access_token) {
-        // Attempt to login to obtain token
-        await login(username, password);
+        // Attempt to login to obtain token using email first, then username
+        try {
+          await login(email, password);
+        } catch (emailLoginError) {
+          try {
+            await login(username, password);
+          } catch (usernameLoginError) {
+            throw new Error(usernameLoginError.message || emailLoginError.message || 'Login failed with both email and username');
+          }
+        }
         access_token = storage.get('token');
         userData = storage.get('user');
         // Prefetch jobs after successful login

--- a/src/components/Register.jsx
+++ b/src/components/Register.jsx
@@ -67,10 +67,14 @@ const Register = () => {
 
     try {
       const userData = await register(formData.username, formData.email, formData.password, selectedField, formData.technicalSkillsPercentage);
-      
-      // Redirect to dashboard immediately
+
+      if (!userData?.token) {
+        throw new Error('Failed to retrieve authentication token.');
+      }
+
+      // Redirect to dashboard once token is confirmed
       navigate('/dashboard', { state: { selectedField, user: userData } });
-      
+
       // Submit CV analysis in background if exists
       const pendingAnalysis = sessionStorage.getItem('pendingCvAnalysis');
       if (pendingAnalysis) {


### PR DESCRIPTION
## Summary
- Attempt login with email first then username if registration response lacks a token, raising explicit error when both fail
- Navigate to dashboard only after confirming token exists and surface errors otherwise

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0c5840954832cabd762a531fb9975