### PR TITLE
Improve login fallback and register redirect logic

### DIFF
--- a/src/components/Register.jsx
+++ b/src/components/Register.jsx
@@ -65,12 +65,22 @@ const Register = () => {
 
     setLoading(true);
 
-    try {
-      const userData = await register(formData.username, formData.email, formData.password, selectedField, formData.technicalSkillsPercentage);
-      
-      // Redirect to dashboard immediately
-      navigate('/dashboard', { state: { selectedField, user: userData } });
-      
+      try {
+        const userData = await register(
+          formData.username,
+          formData.email,
+          formData.password,
+          selectedField,
+          formData.technicalSkillsPercentage
+        );
+
+        if (!userData?.token) {
+          throw new Error('Failed to retrieve authentication token.');
+        }
+
+        // Redirect to dashboard once token is confirmed
+        navigate('/dashboard', { state: { selectedField, user: userData.user } });
+
       // Submit CV analysis in background if exists
       const pendingAnalysis = sessionStorage.getItem('pendingCvAnalysis');
       if (pendingAnalysis) {


### PR DESCRIPTION
## Summary
- Normalize token response handling and try username login if email login fails
- Redirect to dashboard only after confirming token and pass user info correctly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0c5840954832cabd762a531fb9975