### PR TITLE
Make dashboard responsive on mobile

### DIFF
--- a/src/components/dashboard/DashboardHeader.jsx
+++ b/src/components/dashboard/DashboardHeader.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../AuthContext';
 
-const DashboardHeader = ({ user }) => {
+const DashboardHeader = ({ user, onMenuClick }) => {
   const navigate = useNavigate();
   const { logout } = useAuth();
 
@@ -14,9 +14,20 @@ const DashboardHeader = ({ user }) => {
   return (
     <header className="bg-white shadow">
       <div className="max-w-7xl mx-auto py-4 px-4 sm:px-6 lg:px-8 flex justify-between items-center">
-        <div>
-          <h1 className="text-2xl font-bold text-gray-900">Welcome, {user.username || user.email}!</h1>
-          <p className="mt-1 text-sm text-gray-500">Manage your career progress and recommendations</p>
+        <div className="flex items-center">
+          <button
+            type="button"
+            className="md:hidden mr-3 text-gray-700 focus:outline-none"
+            onClick={onMenuClick}
+          >
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
+          </button>
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">Welcome, {user.username || user.email}!</h1>
+            <p className="mt-1 text-sm text-gray-500">Manage your career progress and recommendations</p>
+          </div>
         </div>
         <button
           onClick={handleLogout}

--- a/src/components/dashboard/Sidebar.jsx
+++ b/src/components/dashboard/Sidebar.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
 
-const Sidebar = () => {
+const Sidebar = ({ isOpen, onClose }) => {
   const location = useLocation();
   const currentPath = location.pathname;
 
@@ -82,11 +82,22 @@ const Sidebar = () => {
   ];
 
   return (
-    <div className="h-screen w-64 bg-[var(--card-color)] border-r border-gray-200 fixed left-0 top-0">
-      <div className="flex items-center justify-center h-16 border-b border-gray-200">
+    <div
+      className={`fixed inset-y-0 left-0 z-40 h-screen w-64 bg-[var(--card-color)] border-r border-gray-200 transform transition-transform duration-200 ease-in-out ${isOpen ? 'translate-x-0' : '-translate-x-full'} md:translate-x-0 md:static`}
+    >
+      <div className="flex items-center justify-between h-16 border-b border-gray-200 px-4">
         <span className="text-xl font-bold bg-gradient-to-r from-[var(--primary-color)] to-[var(--secondary-color)] text-transparent bg-clip-text">
           SmartCareerAI
         </span>
+        <button
+          type="button"
+          className="md:hidden text-gray-700 focus:outline-none"
+          onClick={onClose}
+        >
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
       </div>
       <nav className="mt-6">
         <div className="px-4 space-y-1">

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate, Routes, Route } from 'react-router-dom';
 import { useAuth } from '../components/AuthContext';
 import DashboardHeader from '../components/dashboard/DashboardHeader';
@@ -39,13 +39,21 @@ const Dashboard = () => {
     }
   }, []);
 
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
   if (!user) return null;
 
   return (
     <div className="min-h-screen bg-[var(--background-color)] flex">
-      <Sidebar />
-      <div className="flex-1 ml-64">
-        <DashboardHeader user={user} />
+      <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+      {sidebarOpen && (
+        <div
+          className="fixed inset-0 z-30 bg-black/40 md:hidden"
+          onClick={() => setSidebarOpen(false)}
+        ></div>
+      )}
+      <div className="flex-1 ml-0 md:ml-64">
+        <DashboardHeader user={user} onMenuClick={() => setSidebarOpen(true)} />
         <main className="py-6 px-4 sm:px-6 lg:px-8">
           <Routes>
             <Route path="/" element={


### PR DESCRIPTION
## Summary
- Enable mobile sidebar toggle with overlay to make dashboard responsive
- Add hamburger menu to dashboard header for small screens
- Adjust layout to hide sidebar on mobile and restore full width content
- Ensure mobile overlay is visible above content with darker backdrop

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a162c50608832c9c742360c3a30070