### PR TITLE
Align dashboard content with navigation bar

### DIFF
--- a/src/components/AuthContext.jsx
+++ b/src/components/AuthContext.jsx
@@ -190,7 +190,7 @@ export const AuthProvider = ({ children }) => {
           errorMessage = Array.isArray(errorData?.detail)
             ? errorData.detail.map(err => err.msg || err).join('\n')
             : errorData?.detail || errorMessage;
-        } catch (e) {
+        } catch {
           // If we can't parse JSON, try to get text
           const text = await registerResponse.text();
           if (text) errorMessage = text;

--- a/src/components/dashboard/DashboardHeader.jsx
+++ b/src/components/dashboard/DashboardHeader.jsx
@@ -13,7 +13,7 @@ const DashboardHeader = ({ user, onMenuClick }) => {
 
   return (
     <header className="bg-white shadow">
-      <div className="max-w-7xl mx-auto py-4 px-4 sm:px-6 lg:px-8 flex justify-between items-center">
+      <div className="py-4 px-4 sm:px-6 lg:px-8 flex justify-between items-center">
         <div className="flex items-center">
           <button
             type="button"

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -54,7 +54,7 @@ const Dashboard = () => {
       )}
       <div className="flex-1 ml-0 md:ml-64">
         <DashboardHeader user={user} onMenuClick={() => setSidebarOpen(true)} />
-        <main className="py-6 px-4 sm:px-6 lg:px-8">
+        <main className="px-4 pb-6 sm:px-6 lg:px-8">
           <Routes>
             <Route path="/" element={
               <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">


### PR DESCRIPTION
## Summary
- Align dashboard header with page content by removing fixed width constraint
- Remove extra top padding around dashboard content
- Fix unused variable in auth error handling for clean lint run

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a2a1a89740832c904daf31abce78e9